### PR TITLE
Make cookbook compatible with Chef 13/14

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,21 +1,26 @@
 driver:
   name: vagrant
-  require_chef_omnibus: true
+  product: chef
 
 chef_versions:
-- 11
-- 12
+- 13
 
 platforms:
-- name: ubuntu-12.04
+- name: ubuntu-18.04
   run_list:
   - recipe[apt]
-- name: ubuntu-10.04
+- name: ubuntu-16.04
   run_list:
-    - recipe[apt]
-- name: centos-6.4
+  - recipe[apt]
+- name: ubuntu-14.04
+  run_list:
+  - recipe[apt]
 
 suites:
 - name: default
   run_list:
   - recipe[supervisor]
+  attributes:
+    poise-python:
+      options:
+        pip_version: '9.0.3'

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source 'https://supermarket.chef.io'
 metadata
 
 group :integration do

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,11 +3,11 @@ maintainer        "Noah Kantrowitz"
 maintainer_email  "noah@coderanger.net"
 license           "Apache 2.0"
 description       "Installs supervisor and provides resources to configure services"
-version           "0.4.12"
+version           "0.5.0"
 
 recipe "supervisor", "Installs and configures supervisord"
 
-depends "python"
+depends "poise-python"
 
 %w{ ubuntu debian redhat centos fedora amazon smartos raspbian }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 
-include_recipe "python"
+python_runtime 'supervisor' do
+  version '2'
+end
 
 # foodcritic FC023: we prefer not having the resource on non-smartos
 if platform_family?("smartos")
@@ -26,8 +28,9 @@ if platform_family?("smartos")
   end
 end
 
-python_pip "supervisor" do
+python_package "supervisor" do
   action :upgrade
+  python'supervisor'
   version node['supervisor']['version'] if node['supervisor']['version']
 end
 
@@ -85,7 +88,7 @@ when "amazon", "centos", "debian", "fedora", "redhat", "ubuntu", "raspbian"
     variables({
       # TODO: use this variable in the debian platform-family template
       # instead of altering the PATH and calling "which supervisord".
-      :supervisord => "#{node['python']['prefix_dir']}/bin/supervisord"
+      :supervisord => '/usr/local/bin/supervisord'
     })
   end
 


### PR DESCRIPTION
Update the cookbook to use poise-python rather than the deprecated python
cookbook.

To Test, run the following: `kitchen test`
